### PR TITLE
fix dependency loop

### DIFF
--- a/example.css
+++ b/example.css
@@ -1,5 +1,4 @@
 @import "index.css";
-@import "@economist/component-library/index.css";
 
 .Icon.rounded {
   border-radius: 50%;

--- a/package.json
+++ b/package.json
@@ -144,7 +144,6 @@
   },
   "devDependencies": {
     "@economist/component-devpack": "^3.3.1",
-    "@economist/component-library": "^1.0.0",
     "babel": "^5.8.23",
     "babelify": "^6.3.0",
     "browser-sync": "^2.8.2",


### PR DESCRIPTION
This fixes a dependency loop which is causing component-library to fail building. It *does* screw up component-icon's tab CSS in its own example (not in the library, though) but we have to figure out another way around it.