### PR TITLE
3.3.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@economist/component-icon",
-  "version": "3.6.5",
+  "version": "3.6.6",
   "description": "Provides SVG icons images, and classes with SVG background-images.",
   "author": "The Economist (http://economist.com)",
   "license": "ISC",


### PR DESCRIPTION
3.3.6 is just published so that the package.json includes the css for icons, which weren't published in 3.3.5