### PR TITLE
fix: add direct dependency to postcss

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,6 +144,7 @@
     "npm-assets": "^0.1.1",
     "npm-run-all": "^1.5.1",
     "phantomjs-prebuilt": "^2.1.5",
+    "postcss": "^4.1.16",
     "postcss-cli": "^2.5.1",
     "postcss-cssnext": "^2.4.0",
     "postcss-import": "^8.0.2",


### PR DESCRIPTION
component-icon needs it for compile-backgrounds