### PR TITLE
WP-1482 prepare for react 16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ cache:
   directories:
     - node_modules
 node_js:
-  - '4'
+  - '6'
   - stable
 after_success: >-
   travis-after-all && npm run semantic-release && npm run pages -- --repo

--- a/package.json
+++ b/package.json
@@ -112,7 +112,10 @@
     ]
   },
   "dependencies": {
-    "react": "^0.14.8||^15.0.0"
+    "prop-types": "^15.5.0"
+  },
+  "peerDependencies": {
+    "react": "^0.14.8||^15.0.0||^16.0.0"
   },
   "devDependencies": {
     "@economist/doc-pack": "^1.0.7",
@@ -128,10 +131,8 @@
     "browserify": "^13.0.0",
     "browserify-istanbul": "^2.0.0",
     "chai": "^3.5.0",
-    "chai-enzyme": "^0.4.2",
     "chai-spies": "^0.7.1",
     "coveralls": "^2.11.9",
-    "enzyme": "^2.2.0",
     "eslint": "^2.8.0",
     "eslint-config-strict": "^8.5.1",
     "eslint-config-strict-react": "^8.0.1",
@@ -162,8 +163,9 @@
     "postcss-reporter": "^1.3.3",
     "postcss-svg": "fabiosantoscode/postcss-svg#fix-dot-template-postcss-old",
     "postcss-url": "^5.1.1",
-    "react-addons-test-utils": "^0.14.8||^15.0.0",
-    "react-dom": "^0.14.8||^15.0.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
+    "react-test-renderer": "^16.0.0",
     "semantic-release": "^4.3.5",
     "stylelint": "^6.5.1",
     "stylelint-config-strict": "^5.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 let configObj = {};
 export function config(opts) {
@@ -9,13 +10,13 @@ export default class Icon extends React.Component {
 
   static get propTypes() {
     return {
-      icon: React.PropTypes.oneOf(Icon.options.icon).isRequired,
-      background: React.PropTypes.string,
-      color: React.PropTypes.string,
-      size: React.PropTypes.string,
-      className: React.PropTypes.string,
-      uri: React.PropTypes.string,
-      rounded: React.PropTypes.bool,
+      icon: PropTypes.oneOf(Icon.options.icon).isRequired,
+      background: PropTypes.string,
+      color: PropTypes.string,
+      size: PropTypes.string,
+      className: PropTypes.string,
+      uri: PropTypes.string,
+      rounded: PropTypes.bool,
     };
   }
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,11 +1,11 @@
 import 'babel-polyfill';
 import Icon, { config as configIcon } from '../src';
 import React from 'react';
-import TestUtils from 'react-addons-test-utils';
+import ShallowRenderer from 'react-test-renderer/shallow';
 import chai from 'chai';
 chai.should();
 
-const renderer = TestUtils.createRenderer();
+const renderer = new ShallowRenderer();
 /* eslint react/no-danger: 0, id-match: 0 */
 describe('Icon', () => {
   it('is compatible with React.Component', () => {


### PR DESCRIPTION
A few comments from me:

- Enzyme was not used in the tests at all, so I have removed it as a dev dependency.
- `react-addons-test-utils` is [deprecated](https://www.npmjs.com/package/react-addons-test-utils), the functionality it had offered has been moved to `react-test-renderer` and `react-dom`