### PR TITLE
ECNON-127

### DIFF
--- a/icons/print.svg
+++ b/icons/print.svg
@@ -1,7 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 48 48" style="enable-background:new 0 0 48 48;" xml:space="preserve">
-   <rect x="16" y="12" class="st3" width="15.9" height="5.3"/>
-   <path d="M33.3,18.7H14.7c-2.3,0-4,1.7-4,4v8H16V36H32v-5.3h5.3v-8C37.3,20.5,35.6,18.7,33.3,18.7z M29.3,33.3H18.8
-     v-6.7h10.6V33.3z M33.3,24c-0.9,0-1.3-0.6-1.3-1.3s0.6-1.3,1.3-1.3s1.3,0.7,1.3,1.3C34.6,23.4,34,24,33.3,24z"/>
+<svg fill="#FFFFFF" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+    <path d="M19 8H5c-1.66 0-3 1.34-3 3v6h4v4h12v-4h4v-6c0-1.66-1.34-3-3-3zm-3 11H8v-5h8v5zm3-7c-.55 0-1-.45-1-1s.45-1 1-1 1 .45 1 1-.45 1-1 1zm-1-9H6v4h12V3z"/>
+    <path d="M0 0h24v24H0z" fill="none"/>
 </svg>

--- a/icons/print.svg
+++ b/icons/print.svg
@@ -1,4 +1,5 @@
-<svg fill="#FFFFFF" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg version="1.1" fill="#FFFFFF" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
     <path d="M19 8H5c-1.66 0-3 1.34-3 3v6h4v4h12v-4h4v-6c0-1.66-1.34-3-3-3zm-3 11H8v-5h8v5zm3-7c-.55 0-1-.45-1-1s.45-1 1-1 1 .45 1 1-.45 1-1 1zm-1-9H6v4h12V3z"/>
     <path d="M0 0h24v24H0z" fill="none"/>
 </svg>


### PR DESCRIPTION
https://jira.economist.com/browse/ECNON-127

**Description**

The SVG icons for print action are made from black and white part. The white part of a print icon in sharebar is not clickable, but when the user clicks on the black part it's working as expected. This bug is present in various browsers (Firefox, Chrome, Edge). See video attached.

SVG replacement by the provided asset in JIRA
preview:
![new_sharebar](https://user-images.githubusercontent.com/32123092/37392971-0d680c3e-2770-11e8-98b3-80bce93e2f5f.png)
