### PR TITLE
fix: ECNON-127

### DIFF
--- a/icons/print.svg
+++ b/icons/print.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+<svg version="1.1" pointer-events="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 48 48" style="enable-background:new 0 0 48 48;" xml:space="preserve">
    <rect x="16" y="12" class="st3" width="15.9" height="5.3"/>
    <path d="M33.3,18.7H14.7c-2.3,0-4,1.7-4,4v8H16V36H32v-5.3h5.3v-8C37.3,20.5,35.6,18.7,33.3,18.7z M29.3,33.3H18.8


### PR DESCRIPTION
https://jira.economist.com/browse/ECNON-127

**Description**
The SVG icons for print action are made from black and white part. The white part of a print icon in sharebar is not clickable, but when the user clicks on the black part it's working as expected. This bug is present in various browsers (Firefox, Chrome, Edge). See video attached.

**Implementation**
Added an attribute to SVG definition : `pointer-events="none`" which allows mouse events for behind positioned elements.

SVG replacement by the provided asset in JIRA
preview:
![new_sharebar](https://user-images.githubusercontent.com/32123092/37516013-178e378a-290d-11e8-8abc-d0acf86ca663.png)
